### PR TITLE
Fix animate() for Safari

### DIFF
--- a/src/app/engine/engine.service.ts
+++ b/src/app/engine/engine.service.ts
@@ -59,9 +59,13 @@ export class EngineService implements OnDestroy {
     // We have to run this outside angular zones,
     // because it could trigger heavy changeDetection cycles.
     this.ngZone.runOutsideAngular(() => {
-      window.addEventListener('DOMContentLoaded', () => {
+      if (document.readyState !== 'loading') {
         this.render();
-      });
+      } else {
+        window.addEventListener('DOMContentLoaded', () => {
+          this.render();
+        });
+      }
 
       window.addEventListener('resize', () => {
         this.resize();


### PR DESCRIPTION
In Safari, `DOMContentLoaded` event is fired before its handler is added, so it is necessary to check if content is already loaded and call `this.render()`.

https://stackoverflow.com/questions/39993676/code-inside-domcontentloaded-event-not-working